### PR TITLE
Restructure backend for pagination

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,79 +9,49 @@ with open('data.json', 'r') as f:
     isic_data = data['isic']
     wiki_data = data['wiki']
     yandex_data = data['yandex']
+    data = kaggle_data + isic_data + wiki_data + yandex_data
+    shuffle(data)
 
 app = Flask(__name__)
 
 
-def randomize(data, n_images):
-    """Get randomly `n_images` from data.
-
-    Return the unchanged data
-    if the data size is smaller or equal to `n_images`.
-    """
-    if len(data) > n_images:
-        shuffle(data)
-        data = data[:n_images]
-    return data
-
-
-@app.route('/kaggle/<int:n_images>')
-def get_kaggle(n_images):
-    """Get `n_images` images from Kaggle API."""
-    return {'data': randomize(kaggle_data, n_images)}
+def get_page(data, page):
+    """Get nth page of a data, with each page having 20 entries."""
+    begin = page * 20
+    end = page * 20 + 20
+    if begin >= len(data):
+        return []
+    elif end >= len(data):
+        return data[begin:]
+    else:
+        return data[begin:end]
 
 
-@app.route('/isic/<int:n_images>')
-def get_isic(n_images):
-    """Get `n_images` images from ISIC API."""
-    return {'data': randomize(isic_data, n_images)}
+@app.route('/kaggle/<int:page>')
+def get_kaggle(page):
+    """Get a page of 20 images from Kaggle API."""
+    return {'data': get_page(kaggle_data, page)}
 
 
-@app.route('/wiki/<int:n_images>')
-def get_wiki(n_images):
-    """Get `n_images` images from WikiMedia."""
-    return {'data': randomize(wiki_data, n_images)}
+@app.route('/isic/<int:page>')
+def get_isic(page):
+    """Get a page of 20 images from ISIC API."""
+    return {'data': get_page(isic_data, page)}
 
 
-@app.route('/yandex/<int:n_images>')
-def get_yandex(n_images):
-    """Get `n_images` images from WikiMedia."""
-    return {'data': randomize(yandex_data, n_images)}
+@app.route('/wiki/<int:page>')
+def get_wiki(page):
+    """Get a page of 20 images from WikiMedia."""
+    return {'data': get_page(wiki_data, page)}
 
 
-@app.route('/all/<int:n_images>')
-def get_all(n_images):
-    """Get `n_images` images from all sources."""
-    data = kaggle_data + isic_data + wiki_data + yandex_data
-    return {'data': randomize(data, n_images)}
+@app.route('/yandex/<int:page>')
+def get_yandex(page):
+    """Get a page of 20 images from WikiMedia."""
+    return {'data': get_page(yandex_data, page)}
 
 
-@app.route('/kaggle')
-def get_kaggle_full():
-    """Get `n_images` images from Kaggle API."""
-    return {'data': kaggle_data}
-
-
-@app.route('/isic')
-def get_isic_full():
-    """Get `n_images` images from ISIC API."""
-    return {'data': isic_data}
-
-
-@app.route('/wiki')
-def get_wiki_full():
-    """Get `n_images` images from WikiMedia."""
-    return {'data': wiki_data}
-
-
-@app.route('/yandex')
-def get_yandex_full():
-    """Get `n_images` images from WikiMedia."""
-    return {'data': yandex_data}
-
-
-@app.route('/all')
-def get_all_full():
-    """Get `n_images` images from all sources."""
-    data = kaggle_data + isic_data + wiki_data + yandex_data
-    return {'data': data}
+@app.route('/all/<int:page>')
+def get_all(page):
+    """Get a page of 20 images from all sources."""
+    return {'data': get_page(data, page)}

--- a/backend/static_crawler.py
+++ b/backend/static_crawler.py
@@ -33,9 +33,9 @@ if __name__ == '__main__':
     host = 'localhost:5000'
     full_kaggle = get_kaggle_full()
     full_isic = ISIC_getdata(100, 100)
-    wiki_1 = wikimedia_crawl('Basal-cell carcinoma', 150)
-    wiki_2 = wikimedia_crawl('Squamous-cell skin carcinoma', 150)
-    wiki_3 = wikimedia_crawl('Malignant melanoma', 150)
+    wiki_1 = wikimedia_crawl('Basal-cell carcinoma', 250)
+    wiki_2 = wikimedia_crawl('Squamous-cell skin carcinoma', 250)
+    wiki_3 = wikimedia_crawl('Malignant melanoma', 250)
     full_wiki = wiki_1 + wiki_2 + wiki_3
     full_yandex = yandex_crawler(20)
     print('Crawled:')

--- a/backend/static_crawler.py
+++ b/backend/static_crawler.py
@@ -32,8 +32,11 @@ def add_host(data, host):
 if __name__ == '__main__':
     host = 'localhost:5000'
     full_kaggle = get_kaggle_full()
-    full_isic = ISIC_getdata(300, 300)
-    full_wiki = wikimedia_crawl(500)
+    full_isic = ISIC_getdata(100, 100)
+    wiki_1 = wikimedia_crawl('Basal-cell carcinoma', 150)
+    wiki_2 = wikimedia_crawl('Squamous-cell skin carcinoma', 150)
+    wiki_3 = wikimedia_crawl('Malignant melanoma', 150)
+    full_wiki = wiki_1 + wiki_2 + wiki_3
     full_yandex = yandex_crawler(20)
     print('Crawled:')
     print(len(full_kaggle), 'image(s) from Kaggle')

--- a/backend/wikimedia/wikicrawl.py
+++ b/backend/wikimedia/wikicrawl.py
@@ -34,6 +34,7 @@ def wikimedia_crawl(cancer_type, result=100):
         if title.endswith('pdf'):
             # Skip pdf files
             continue
+        title = title.replace('_', ' ')
         origin_url = "https://commons.wikimedia.org" + info["href"]
         data = {}
         # request to origin url to get full image

--- a/backend/wikimedia/wikicrawl.py
+++ b/backend/wikimedia/wikicrawl.py
@@ -2,7 +2,12 @@ import requests
 from bs4 import BeautifulSoup
 
 
-def wikimedia_crawl(result=100):
+def make_query_key(search_key):
+    """Make search key on Wikimedia."""
+    return search_key.replace(' ', '+')
+
+
+def wikimedia_crawl(cancer_type, result=100):
     """Get images from wikimedia when search for skin cancer.
     Parameters:
         result : int.
@@ -16,7 +21,7 @@ def wikimedia_crawl(result=100):
             - title: the title of the image
     """
     url = f"https://commons.wikimedia.org/w/index.php?title=Special:Search&limit=\
-    {result}&offset=0&profile=default&search=Basal-cell+carcinoma\
+    {result}&offset=0&profile=default&search={make_query_key(cancer_type)}\
     &advancedSearch-current={{}}&ns0=1&ns6=1&ns12=1&ns14=1&ns100=1&ns106=1"
 
     response = requests.get(url)
@@ -42,4 +47,4 @@ def wikimedia_crawl(result=100):
 
 
 if __name__ == '__main__':
-    wikimedia_crawl(100)
+    wikimedia_crawl('Basal-cell carcinoma', 100)

--- a/backend/wikimedia/wikicrawl.py
+++ b/backend/wikimedia/wikicrawl.py
@@ -31,6 +31,9 @@ def wikimedia_crawl(cancer_type, result=100):
     data_list = []
     for info in infos:
         title = info["href"].replace("/wiki/", "")
+        if title.endswith('pdf'):
+            # Skip pdf files
+            continue
         origin_url = "https://commons.wikimedia.org" + info["href"]
         data = {}
         # request to origin url to get full image

--- a/backend/wikimedia/wikicrawl.py
+++ b/backend/wikimedia/wikicrawl.py
@@ -2,8 +2,8 @@ import requests
 from bs4 import BeautifulSoup
 
 
-def make_query_key(search_key):
-    """Make search key on Wikimedia."""
+def make_query(search_key):
+    """Make search query from search key on Wikimedia."""
     return search_key.replace(' ', '+')
 
 
@@ -20,20 +20,21 @@ def wikimedia_crawl(cancer_type, result=100):
             - original: URL to the web page where the image is found
             - title: the title of the image
     """
-    url = f"https://commons.wikimedia.org/w/index.php?title=Special:Search&limit=\
-    {result}&offset=0&profile=default&search={make_query_key(cancer_type)}\
-    &advancedSearch-current={{}}&ns0=1&ns6=1&ns12=1&ns14=1&ns100=1&ns106=1"
+    url = 'https://commons.wikimedia.org/w/'
+    url += f'index.php?title=Special:Search&limit={result}&offset=0'
+    url += '&ns0=1&ns6=1&ns12=1&ns14=1&ns100=1&ns106=1'
+    url += f'&search={make_query(cancer_type)}'
+    url += '+filetype%3Abitmap'
+    url += '&advancedSearch-current={"fields":{"filetype":"bitmap"}}'
 
     response = requests.get(url)
     soup = BeautifulSoup(response.content, "html.parser")
 
     infos = soup.find_all("a", "image")
+    print(len(infos))
     data_list = []
     for info in infos:
         title = info["href"].replace("/wiki/", "")
-        if title.endswith('pdf'):
-            # Skip pdf files
-            continue
         title = title.replace('_', ' ')
         origin_url = "https://commons.wikimedia.org" + info["href"]
         data = {}


### PR DESCRIPTION
In this PR, I restructure backend for pagination-oriented to fit more with the frontend design, so each request is `source/<page>` instead of `source/<n_images>` like before.

I also:

- Filter out pdf files
- Add more page search for wiki
- Replace `_` with ` ` for titles of images crawled from wiki 